### PR TITLE
Performance fixes

### DIFF
--- a/MapView/Map/RMAbstractWebMapSource.h
+++ b/MapView/Map/RMAbstractWebMapSource.h
@@ -54,4 +54,6 @@
     @return An array of tile URLs to download, listed bottom to top. */
 - (NSArray *)URLsForTile:(RMTile)tile;
 
+- (void)downloadImageForTile:(RMTile)tile cache:(RMTileCache *)cache visibleMapRect:(RMIntegralRect)mapRect completion:(void(^)(void))completion;
+
 @end

--- a/MapView/Map/RMAbstractWebMapSource.m
+++ b/MapView/Map/RMAbstractWebMapSource.m
@@ -30,9 +30,14 @@
 #import "RMTileCache.h"
 #import "RMConfiguration.h"
 
+#import "RMTileCacheDownloadOperation.h"
+
 #define HTTP_404_NOT_FOUND 404
 
-@implementation RMAbstractWebMapSource
+@implementation RMAbstractWebMapSource {
+    NSOperationQueue *_downloadQueue;
+    NSMapTable *_enqueuedOperations;
+}
 
 @synthesize retryCount, requestTimeoutSeconds;
 
@@ -43,8 +48,81 @@
 
     self.retryCount = RMAbstractWebMapSourceDefaultRetryCount;
     self.requestTimeoutSeconds = RMAbstractWebMapSourceDefaultWaitSeconds;
+    
+    _downloadQueue = [[NSOperationQueue alloc] init];
+    _downloadQueue.maxConcurrentOperationCount = 6;
+    
+    _enqueuedOperations = [[NSMapTable alloc] initWithKeyOptions:NSPointerFunctionsCopyIn valueOptions:NSPointerFunctionsWeakMemory capacity:64];
 
     return self;
+}
+
+- (void)cancelAllDownloads
+{
+    [_downloadQueue cancelAllOperations];
+}
+
+- (BOOL)operationExistsForTile:(RMTile)tile
+{
+    BOOL exists = NO;
+    
+    @synchronized(_enqueuedOperations) {
+        NSOperation *operation = [_enqueuedOperations objectForKey:[RMTileCache tileHash:tile]];
+        exists = operation != NULL && ![operation isCancelled];
+    }
+    
+    return exists;
+}
+
+- (void)cancelDownloadsIrrelevantToTile:(RMTile)tile visibleMapRect:(RMIntegralRect)mapRect
+{
+    NSArray *operations = nil;
+    
+    @synchronized(_enqueuedOperations) {
+        operations = [_enqueuedOperations.objectEnumerator.allObjects copy];
+    }
+    
+    for (RMTileCacheDownloadOperation *operation in operations) {
+        if ([operation isCancelled]) {
+            continue;
+        }
+        
+        if (operation.tile.zoom != tile.zoom) {
+            [operation cancel];
+        } else if (!RMIntegralRectContainsPoint(mapRect, RMIntegralPointMake(operation.tile.x, operation.tile.y))){
+            [operation cancel];
+        }
+    }
+}
+
+- (void)registerOperation:(RMTileCacheDownloadOperation *)operation
+{
+    @synchronized(_enqueuedOperations) {
+        [_enqueuedOperations setObject:operation forKey:[RMTileCache tileHash:operation.tile]];
+    }
+}
+
+- (void)downloadImageForTile:(RMTile)tile cache:(RMTileCache *)cache visibleMapRect:(RMIntegralRect)mapRect completion:(void (^)(void))completion
+{
+    if ([self operationExistsForTile:tile]) {
+        return;
+    }
+    
+    [self cancelDownloadsIrrelevantToTile:tile visibleMapRect:mapRect];
+    
+    dispatch_async(dispatch_get_main_queue(), ^{
+        [[NSNotificationCenter defaultCenter] postNotificationName:RMTileRequested object:[NSNumber numberWithUnsignedLongLong:RMTileKey(tile)]];
+    });
+    
+    RMTileCacheDownloadOperation *operation = [[RMTileCacheDownloadOperation alloc] initWithTile:tile forTileSource:self usingCache:cache completion:^{
+        [[NSNotificationCenter defaultCenter] postNotificationName:RMTileRetrieved object:[NSNumber numberWithUnsignedLongLong:RMTileKey(tile)]];
+        if (completion) {
+            completion();
+        }
+    }];
+    
+    [_downloadQueue addOperation:operation];
+    [self registerOperation:operation];
 }
 
 - (NSURL *)URLForTile:(RMTile)tile
@@ -61,126 +139,9 @@
 
 - (UIImage *)imageForTile:(RMTile)tile inCache:(RMTileCache *)tileCache
 {
-    __block UIImage *image = nil;
-
-	tile = [[self mercatorToTileProjection] normaliseTile:tile];
-
-    // Return NSNull here so that the RMMapTiledLayerView will try to
-    // fetch another tile if missingTilesDepth > 0
-    if ( ! [self tileSourceHasTile:tile])
-        return (UIImage *)[NSNull null];
-
-    if (self.isCacheable)
-    {
-        image = [tileCache cachedImage:tile withCacheKey:[self uniqueTilecacheKey]];
-
-        if (image)
-            return image;
-    }
-
-    dispatch_async(dispatch_get_main_queue(), ^(void)
-    {
-        [[NSNotificationCenter defaultCenter] postNotificationName:RMTileRequested object:[NSNumber numberWithUnsignedLongLong:RMTileKey(tile)]];
-    });
-
-    NSArray *URLs = [self URLsForTile:tile];
-
-    if ([URLs count] == 0)
-    {
-        return nil;
-    }
-    else if ([URLs count] > 1)
-    {
-        // fill up collection array with placeholders
-        //
-        NSMutableArray *tilesData = [NSMutableArray arrayWithCapacity:[URLs count]];
-
-        for (NSUInteger p = 0; p < [URLs count]; ++p)
-            [tilesData addObject:[NSNull null]];
-
-        dispatch_group_t fetchGroup = dispatch_group_create();
-
-        for (NSUInteger u = 0; u < [URLs count]; ++u)
-        {
-            NSURL *currentURL = [URLs objectAtIndex:u];
-
-            dispatch_group_async(fetchGroup, dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^(void)
-            {
-                NSData *tileData = nil;
-
-                for (NSUInteger try = 0; tileData == nil && try < self.retryCount; ++try)
-                {
-                    NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:currentURL];
-                    [request setCachePolicy:NSURLRequestReloadIgnoringLocalCacheData];
-                    [request setTimeoutInterval:(self.requestTimeoutSeconds / (CGFloat)self.retryCount)];
-                    tileData = [NSURLConnection sendBrandedSynchronousRequest:request returningResponse:nil error:nil];
-                }
-
-                if (tileData)
-                {
-                    @synchronized (self)
-                    {
-                        // safely put into collection array in proper order
-                        //
-                        [tilesData replaceObjectAtIndex:u withObject:tileData];
-                    };
-                }
-            });
-        }
-
-        // wait for whole group of fetches (with retries) to finish, then clean up
-        //
-        dispatch_group_wait(fetchGroup, dispatch_time(DISPATCH_TIME_NOW, NSEC_PER_SEC * self.requestTimeoutSeconds));
-#if ! OS_OBJECT_USE_OBJC
-        dispatch_release(fetchGroup);
-#endif
-
-        // composite the collected images together
-        //
-        for (NSData *tileData in tilesData)
-        {
-            if (tileData && [tileData isKindOfClass:[NSData class]] && [tileData length])
-            {
-                if (image != nil)
-                {
-                    UIGraphicsBeginImageContext(image.size);
-                    [image drawAtPoint:CGPointMake(0,0)];
-                    [[UIImage imageWithData:tileData] drawAtPoint:CGPointMake(0,0)];
-
-                    image = UIGraphicsGetImageFromCurrentImageContext();
-                    UIGraphicsEndImageContext();
-                }
-                else
-                {
-                    image = [UIImage imageWithData:tileData];
-                }
-            }
-        }
-    }
-    else
-    {
-        for (NSUInteger try = 0; image == nil && try < self.retryCount; ++try)
-        {
-            NSHTTPURLResponse *response = nil;
-            NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[URLs objectAtIndex:0]];
-            [request setCachePolicy:NSURLRequestReloadIgnoringLocalCacheData];
-            [request setTimeoutInterval:(self.requestTimeoutSeconds / (CGFloat)self.retryCount)];
-            image = [UIImage imageWithData:[NSURLConnection sendBrandedSynchronousRequest:request returningResponse:&response error:nil]];
-
-            if (response.statusCode == HTTP_404_NOT_FOUND)
-                break;
-        }
-    }
-
-    if (image && self.isCacheable)
-        [tileCache addImage:image forTile:tile withCacheKey:[self uniqueTilecacheKey]];
-
-    dispatch_async(dispatch_get_main_queue(), ^(void)
-    {
-        [[NSNotificationCenter defaultCenter] postNotificationName:RMTileRetrieved object:[NSNumber numberWithUnsignedLongLong:RMTileKey(tile)]];
-    });
-
-    return image;
+    // This method only considers the cache. Use downloadImageForTile: to download a
+    // tile nonexistant in the cache.
+    return [tileCache cachedImage:tile withCacheKey:[self uniqueTilecacheKey]];
 }
 
 @end

--- a/MapView/Map/RMFoundation.c
+++ b/MapView/Map/RMFoundation.c
@@ -83,6 +83,27 @@ bool RMProjectedSizeContainsProjectedSize(RMProjectedSize size1, RMProjectedSize
     return (size1.width >= size2.width && size1.height >= size2.height);
 }
 
+bool RMIntegralRectContainsPoint(RMIntegralRect rect, RMIntegralPoint point)
+{
+    int minX = rect.origin.x;
+    int maxX = rect.origin.x + rect.size.width;
+    int minY = rect.origin.y;
+    int maxY = rect.origin.y + rect.size.height;
+    
+    int x = point.x;
+    int y = point.y;
+    
+    return (x >= minX && x <= maxX && y >= minY && y <= maxY);
+}
+
+RMIntegralPoint RMIntegralPointMake(int x, int y)
+{
+    RMIntegralPoint point;
+    point.x = x;
+    point.y = y;
+    return point;
+}
+
 RMProjectedPoint RMScaleProjectedPointAboutPoint(RMProjectedPoint point, float factor, RMProjectedPoint pivot)
 {
 	point.x = (point.x - pivot.x) * factor + pivot.x;

--- a/MapView/Map/RMFoundation.h
+++ b/MapView/Map/RMFoundation.h
@@ -53,6 +53,19 @@ typedef struct {
 	RMProjectedSize size;
 } RMProjectedRect;
 
+typedef struct {
+    int x, y;
+} RMIntegralPoint;
+
+typedef struct {
+    int width, height;
+} RMIntegralSize;
+
+typedef struct {
+    RMIntegralPoint origin;
+    RMIntegralSize size;
+} RMIntegralRect;
+
 #if __OBJC__
 /*! \struct RMSphericalTrapezium
  \brief a rectangle, specified by two corner coordinates */
@@ -78,6 +91,11 @@ bool RMProjectedRectContainsProjectedRect(RMProjectedRect rect1, RMProjectedRect
 bool RMProjectedRectContainsProjectedPoint(RMProjectedRect rect, RMProjectedPoint point);
 
 bool RMProjectedSizeContainsProjectedSize(RMProjectedSize size1, RMProjectedSize size2);
+
+#pragma mark -
+
+bool RMIntegralRectContainsPoint(RMIntegralRect rect, RMIntegralPoint point);
+RMIntegralPoint RMIntegralPointMake(int x, int y);
 
 #pragma mark -
 

--- a/MapView/Map/RMMapView.h
+++ b/MapView/Map/RMMapView.h
@@ -284,6 +284,8 @@ typedef enum : NSUInteger {
 
 - (void)setProjectedConstraintsSouthWest:(RMProjectedPoint)southWest northEast:(RMProjectedPoint)northEast;
 
+- (CGRect)visibleRect;
+
 #pragma mark - Snapshots
 
 /** @name Capturing Snapshots of the Map View */

--- a/MapView/Map/RMMapView.m
+++ b/MapView/Map/RMMapView.m
@@ -1414,6 +1414,11 @@
     [self correctPositionOfAllAnnotations];
 }
 
+- (CGRect)visibleRect
+{
+    return [_mapScrollView convertRect:_mapScrollView.bounds toView:_tiledLayersSuperview];
+}
+
 - (UIView *)viewForZoomingInScrollView:(UIScrollView *)scrollView
 {
     return _tiledLayersSuperview;

--- a/MapView/Map/RMTileCacheDownloadOperation.h
+++ b/MapView/Map/RMTileCacheDownloadOperation.h
@@ -33,8 +33,10 @@
 
 @interface RMTileCacheDownloadOperation : NSOperation
 
-- (id)initWithTile:(RMTile)tile forTileSource:(id <RMTileSource>)source usingCache:(RMTileCache *)cache;
+- (instancetype)initWithTile:(RMTile)tile forTileSource:(id <RMTileSource>)source usingCache:(RMTileCache *)cache;
+- (instancetype)initWithTile:(RMTile)tile forTileSource:(id <RMTileSource>)source usingCache:(RMTileCache *)cache completion:(void(^)(void))completion;
 
 @property (nonatomic, strong) NSError *error;
+@property (nonatomic, assign, readonly) RMTile tile;
 
 @end

--- a/MapView/Map/RMTileCacheDownloadOperation.m
+++ b/MapView/Map/RMTileCacheDownloadOperation.m
@@ -29,68 +29,141 @@
 #import "RMAbstractWebMapSource.h"
 #import "RMConfiguration.h"
 
-@implementation RMTileCacheDownloadOperation
-{
-    RMTile _tile;
+@interface RMTileCacheDownloadOperation ()
+
+@property (readwrite, getter=isExecuting) BOOL executing;
+@property (readwrite, getter=isFinished) BOOL finished;
+@property (readwrite, getter=isCancelled) BOOL cancelled;
+
+@end
+
+@implementation RMTileCacheDownloadOperation {
     __weak id <RMTileSource>_source;
     __weak RMTileCache *_cache;
+    void(^_completion)();
+    __weak NSURLSessionDataTask *_task;
+    NSURLSession *_session;
+    NSURLRequest *_request;
+    NSUInteger _attempt;
 }
 
-- (id)initWithTile:(RMTile)tile forTileSource:(id <RMTileSource>)source usingCache:(RMTileCache *)cache
+@synthesize executing = _executing, finished = _finished, cancelled = _cancelled;
+
++ (NSSet *)keyPathsForValuesAffectingValueForKey:(NSString *)key
 {
-    if (!(self = [super init]))
-        return nil;
+    NSSet *keyPaths = [super keyPathsForValuesAffectingValueForKey:key];
+    
+    if ([key isEqualToString:@"isExecuting"]) {
+        keyPaths = [keyPaths setByAddingObject:@"executing"];
+    } else if ([key isEqualToString:@"isFinished"]) {
+        keyPaths = [keyPaths setByAddingObject:@"finished"];
+    } else if ([key isEqualToString:@"isCancelled"]) {
+        keyPaths = [keyPaths setByAddingObject:@"cancelled"];
+    }
+    
+    return keyPaths;
+}
 
+- (instancetype)initWithTile:(RMTile)tile
+               forTileSource:(id <RMTileSource>)source
+                  usingCache:(RMTileCache *)cache
+{
+    return [self initWithTile:tile
+                forTileSource:source
+                   usingCache:cache
+                   completion:nil];
+}
+
+- (instancetype)initWithTile:(RMTile)tile
+               forTileSource:(id<RMTileSource>)source
+                  usingCache:(RMTileCache *)cache
+                  completion:(void (^)(void))completion
+{
     NSAssert([source isKindOfClass:[RMAbstractWebMapSource class]], @"only web-based tile sources are supported for downloading");
-
-    _tile   = tile;
-    _source = source;
-    _cache  = cache;
-
+    
+    if (self = [super init]) {
+        _tile = tile;
+        _source = source;
+        _cache = cache;
+        _completion = [completion copy];
+        
+        _session = [NSURLSession sessionWithConfiguration:[NSURLSessionConfiguration defaultSessionConfiguration]];
+        _request = [self createURLRequestForURL:[(RMAbstractWebMapSource *)_source URLForTile:_tile]];
+    }
     return self;
 }
 
-- (void)main
+- (BOOL)isAsynchronous
 {
-    if ( ! _source || ! _cache)
-        [self cancel];
+    return YES;
+}
 
-    if ([self isCancelled])
+- (void)start
+{
+    if (!_source || !_cache || [self isCancelled]) {
+        self.finished = YES;
         return;
-
-    if ( ! [_cache cachedImage:_tile withCacheKey:[_source uniqueTilecacheKey] bypassingMemoryCache:YES])
-    {
-        if ([self isCancelled])
-            return;
-
-        NSURL *tileURL = [(RMAbstractWebMapSource *)_source URLForTile:_tile];
-        NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:tileURL];
-        request.cachePolicy = NSURLRequestReloadIgnoringLocalCacheData;
-        NSError *error = nil;
-        NSData *data = [NSURLConnection sendBrandedSynchronousRequest:request
-                                                    returningResponse:nil
-                                                                error:&error];
-
-        if ( ! data || error != nil)
-        {
-            if (error != nil)
-            {
-                self.error = error;
-            }
-            else
-            {
-                self.error = [NSError errorWithDomain:NSURLErrorDomain
-                                                 code:NSURLErrorUnknown
-                                             userInfo:nil];
-            }
-
-            [self cancel];
-        }
-        else
-        {
-            [_cache addDiskCachedImageData:data forTile:_tile withCacheKey:[_source uniqueTilecacheKey]];
-        }
     }
+    
+    _attempt = 0;
+    _task = [self createDataTaskForRequest:_request];
+    [_task resume];
+    
+    self.executing = YES;
+}
+
+- (void)cancel
+{
+    if ([self isCancelled]) {
+        return;
+    }
+    
+    [_task cancel];
+    self.cancelled = YES;
+}
+
+- (NSURLRequest *)createURLRequestForURL:(NSURL *)URL
+{
+    NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:URL];
+    request.cachePolicy = NSURLRequestReloadIgnoringLocalCacheData;
+    request.timeoutInterval = [(RMAbstractWebMapSource *)_source requestTimeoutSeconds];
+    [request setValue:[[RMConfiguration sharedInstance] userAgent] forHTTPHeaderField:@"User-Agent"];
+    return request;
+}
+
+- (NSURLSessionDataTask *)createDataTaskForRequest:(NSURLRequest *)request
+{
+    NSURLSessionDataTask *task = [_session dataTaskWithRequest:request completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
+        NSInteger statusCode = [(NSHTTPURLResponse *)response statusCode];
+        
+        if (statusCode != 200) {
+            self.error = [NSError errorWithDomain:@"com.mapbox.error.http" code:statusCode userInfo:nil];
+        } else if (!error && data) {
+            [_cache addDiskCachedImageData:data forTile:_tile withCacheKey:[_source uniqueTilecacheKey]];
+        } else if (error) {
+            self.error = error;
+        } else {
+            self.error = [NSError errorWithDomain:NSURLErrorDomain code:NSURLErrorUnknown userInfo:nil];
+        }
+        
+        if (!self.error && data) {
+            if (_completion) {
+                dispatch_async(dispatch_get_main_queue(), ^{
+                    _completion();
+                });
+            }
+        }
+        
+        if (self.error && _attempt < [(RMAbstractWebMapSource *)_source retryCount]) {
+            _attempt++;
+            _task = [self createDataTaskForRequest:request];
+            [_task resume];
+        } else {
+            self.executing = NO;
+            self.finished = YES;
+        }
+    }];
+    return task;
 }
 
 @end


### PR DESCRIPTION
# W

Several changes aimed at improving performance:
- cancel operations for tiles outside the visible map rect
- cancel operations for tiles on a different zoom level
- use one operation queue per tile source, instead of clogging up the system pool of dispatch queues
- use NSURLSession instead of synchronous NSURLConnection
- do not synchronously download tile for higher zoom level if a lower level tile is being downloaded. Instead, check cache.

@rickrets @nkooiker 
